### PR TITLE
README: Fix broken markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ layout: page
 title: About
 permalink: /about/
 ---
-[pubtest.me](pubtestme) is an index of reporting on Australian
+[pubtest.me][pubtestme] is an index of reporting on Australian
 Federal Government activities that are at odds with the public interest.
 
 If you see incorrect or unsubstantiated information, or think an existing
@@ -15,13 +15,13 @@ more of the following criteria:
 
 1. A public institution has handed down a report that demonstrates an
 activity failed to meet legal obligations or required standards. For example,
-reports published by the [Australian National Audit Office (ANAO)](anao)
+reports published by the [Australian National Audit Office (ANAO)][anao]
 
 2. An activity that has been reported to disregard advice from relevant public
 servants, research or scientific organisations to the detriment of the public
 
 3. Activities reported to [breach ministerial standards as set out by the Department of
-the Prime Minister and Cabinet](pmc-ministerial-standards)
+the Prime Minister and Cabinet][pmc-ministerial-standards]
 
 4. Activities reported to breach the constitution, federal or state law.
 


### PR DESCRIPTION
The wrong style of braces was used for reference-style links.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>