### PR TITLE
posts: robodebt: Mark as "perspectives converging"

### DIFF
--- a/_posts/2016-06-28-online-compliance-intervention-program.md
+++ b/_posts/2016-06-28-online-compliance-intervention-program.md
@@ -1,6 +1,7 @@
 ---
 title: Income Data Matching for Welfare Recipients
 layout: post
+tags: [ "Perspectives Converging" ]
 summary: |
   "In July 2016 the Department of Human Services (DHS) - Centrelink - launched
   a new online compliance intervention (OCI) system for raising and recovering


### PR DESCRIPTION
The controversial aspect of the program has been suspended[1], so we're past
"adverse finding".

[1] https://www.theguardian.com/australia-news/2019/nov/19/robodebt-government-abandons-key-part-of-debt-recovery-scheme-in-major-overhaul

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>